### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+rsplib (3.4.3-1ubuntu2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster (oldstable):
+    + Build-Depends: Drop versioned constraint on cmake, dpkg-dev, libbz2-dev
+      and libsctp-dev.
+    + rsplib-registrar: Drop versioned constraint on lsb-base in Depends.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 19 Oct 2022 18:27:46 -0000
+
 rsplib (3.4.3-1ubuntu1) jammy; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,11 @@ Section: net
 Priority: optional
 Maintainer: Thomas Dreibholz <dreibh@iem.uni-due.de>
 Homepage: https://www.uni-due.de/~be0001/rserpool/
-Build-Depends: cmake (>= 3.0.2) | cmake3,
+Build-Depends: cmake | cmake3,
                debhelper (>= 9),
-               dpkg-dev (>= 1.16.1~),
-               libbz2-dev (>= 1.0),
+               libbz2-dev,
                libfile-fcntllock-perl,
-               libsctp-dev (>= 1.0.8),
+               libsctp-dev,
                libtool,
                qtbase5-dev,
                qtbase5-dev-tools,
@@ -98,7 +97,7 @@ Description: documentation of the RSerPool implementation RSPLIB
 Package: rsplib-registrar
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
-Depends: lsb-base (>= 3.2-14),
+Depends: lsb-base,
          ${misc:Depends},
          ${shlibs:Depends}
 Recommends: rsplib-doc (>= ${source:Version})


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/rsplib/9b3f5626-221c-4a70-a1b5-1e1577de1433.



These changes affect the binary packages; see the
[debdiff](https://janitor.debian.net/api/run/9b3f5626-221c-4a70-a1b5-1e1577de1433/debdiff?filter_boring=1)


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/9b3f5626-221c-4a70-a1b5-1e1577de1433/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/9b3f5626-221c-4a70-a1b5-1e1577de1433/diffoscope)).
